### PR TITLE
New Jcapi version functionality and x25 improvements

### DIFF
--- a/src/main/java/org/neociclo/capi20/message/DataB3Ind.java
+++ b/src/main/java/org/neociclo/capi20/message/DataB3Ind.java
@@ -110,7 +110,7 @@ public class DataB3Ind extends ReceiveMessage {
         setDataLength(readWord(buf));
         setDataHandle(readWord(buf));
         setRawFlags(readWord(buf));
-//        buf.skipBytes(QWORD_SIZE); // TODO skip 64-bits data pointer ???
+        buf.skipBytes(QWORD_SIZE); // skip 64-bits data pointer
 
         byte[] data = new byte[dataLength];
         buf.readBytes(data);

--- a/src/main/java/org/neociclo/capi20/message/DataB3Req.java
+++ b/src/main/java/org/neociclo/capi20/message/DataB3Req.java
@@ -32,7 +32,7 @@ import org.neociclo.capi20.util.Bits;
  */
 public class DataB3Req extends SendMessage {
 
-    public static final int SIZEOF_DATA_B3_REQ = 0x16;
+    public static final int SIZEOF_DATA_B3_REQ = 0x1E;
 
     private NCCI ncci;
     private int dataLength;
@@ -100,6 +100,7 @@ public class DataB3Req extends SendMessage {
         writeWord(buf, (data == null ? getDataLength() : data.length)); // data length
         writeWord(buf, getDataHandle()); // data handle
         writeWord(buf, getRawFlags());
+        writeQword(buf, 0); // 64 bit data pointer
         buf.writeBytes(data);
     }
 

--- a/src/main/java/org/neociclo/isdn/netty/channel/IsdnChannelConfig.java
+++ b/src/main/java/org/neociclo/isdn/netty/channel/IsdnChannelConfig.java
@@ -76,6 +76,11 @@ public final class IsdnChannelConfig extends DefaultChannelConfig {
 
     // CONNECT_B3_REQ - X.25 Network User Address
     private String x25Nua;
+    //User data for ncpi
+    private byte[] x25UserData;
+    
+    //Sometimes you dont want to create a specific NCPI on connect_b3_req cause some external clients cant handle ok
+    private boolean dontCreateNCPI;
 
     /**
      * Creates a new instance.
@@ -267,5 +272,21 @@ public final class IsdnChannelConfig extends DefaultChannelConfig {
     public ChannelPipelineFactory getPipelineFactory() {
         return pipelineFactory;
     }
+
+	public boolean isDontCreateNCPI() {
+		return dontCreateNCPI;
+	}
+
+	public void setDontCreateNCPI(boolean dontCreateNCPI) {
+		this.dontCreateNCPI = dontCreateNCPI;
+	}
+
+	public byte[] getX25UserData() {
+		return x25UserData;
+	}
+	
+	public void setX25UserData(byte[] userdata) {
+		this.x25UserData=userdata;
+	}
 
 }

--- a/src/main/java/org/neociclo/isdn/netty/channel/IsdnServerPipelineSink.java
+++ b/src/main/java/org/neociclo/isdn/netty/channel/IsdnServerPipelineSink.java
@@ -146,7 +146,7 @@ final class IsdnServerPipelineSink extends AbstractChannelSink {
     }
 
     private void close(IsdnServerChannel channel, ChannelFuture future) {
-        logger.warn("CLOSE not implemented!!!");
+    	channel.bound = false;
     }
 
     private void bind(IsdnServerChannel channel, ChannelFuture future, IsdnSocketAddress localAddress) {

--- a/src/main/java/org/neociclo/isdn/netty/channel/MessageBuilder.java
+++ b/src/main/java/org/neociclo/isdn/netty/channel/MessageBuilder.java
@@ -232,7 +232,12 @@ public class MessageBuilder {
 	    IsdnChannelConfig config = channel.getConfig();
 	
 	    int b3Protocol = b3Protocol(config.getB3());
-	    NCPI ncpi = createNcpi(channel, b3Protocol, CONNECT_B3_REQ);
+	    NCPI ncpi;
+	    if (config.isDontCreateNCPI()) {
+	    	ncpi=null;
+	    } else {
+	    	ncpi = createNcpi(channel, b3Protocol, CONNECT_B3_REQ);
+	    }
 	
 	    ConnectB3Req req = new ConnectB3Req();
 	    req.setPlci(config.getPlci());

--- a/src/main/java/org/neociclo/isdn/netty/channel/PlciConnectionHandler.java
+++ b/src/main/java/org/neociclo/isdn/netty/channel/PlciConnectionHandler.java
@@ -18,6 +18,7 @@ package org.neociclo.isdn.netty.channel;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 
 import org.neociclo.capi20.CapiException;
 import org.neociclo.capi20.message.CapiMessage;
@@ -32,6 +33,8 @@ final class PlciConnectionHandler {
     private BlockingQueue<CapiMessage> messageQueue = new LinkedBlockingQueue<CapiMessage>(7);
     private CapiMessage received;
     private Integer plci;
+    
+    private static final long TIMEOUT_SECONDS = 90;
 
     public PlciConnectionHandler(Integer plci) {
         this.plci = plci;
@@ -43,7 +46,7 @@ final class PlciConnectionHandler {
 
     public void waitForSignal() throws CapiException {
         try {
-            received = messageQueue.take();
+            received = messageQueue.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
             throw new CapiException(Info.EXCHANGE_RESOURCE_ERROR, "interrupted blocking queue take()");
         }

--- a/src/main/java/org/neociclo/isdn/netty/handler/ParameterHelper.java
+++ b/src/main/java/org/neociclo/isdn/netty/handler/ParameterHelper.java
@@ -20,6 +20,8 @@ import static net.sourceforge.jcapi.message.parameter.IPartyNumberConstants.*;
 import static org.neociclo.capi20.parameter.CompatibilityInformationProfile.*;
 import static org.neociclo.capi20.parameter.SubAddressType.*;
 
+import org.apache.commons.lang.ArrayUtils;
+
 import net.sourceforge.jcapi.message.parameter.AdditionalInfo;
 import net.sourceforge.jcapi.message.parameter.BProtocol;
 import net.sourceforge.jcapi.message.parameter.BearerCapability;
@@ -75,11 +77,18 @@ public class ParameterHelper {
         }
         byte[] facilities = (config.getFacilities() != null && config.getFacilities().hasFacilities() ? config
                 .getFacilities().encoded() : new byte[] {});
+        
+        //x25 userdata
+        byte[] userdata = new byte[] {};
+        if (! ArrayUtils.isEmpty(config.getX25UserData())) {
+        	userdata=config.getX25UserData();
+        }
 
-        byte[] x25Contents = new byte[x25AddressBlock.length + facilities.length];
+        byte[] x25Contents = new byte[x25AddressBlock.length + facilities.length + userdata.length];
         System.arraycopy(x25AddressBlock, 0, x25Contents, 0, x25AddressBlock.length);
         System.arraycopy(facilities, 0, x25Contents, x25AddressBlock.length, facilities.length);
-
+        System.arraycopy(userdata, 0, x25Contents, x25AddressBlock.length + facilities.length, userdata.length);
+        
         NCPI ncpi = new NCPI(b3Protocol, messageType.intValue());
         ncpi.setDeliveryConfirmationEnabled(x25Dbit);
         ncpi.setX25LogicalChannelGroup(x25Group);

--- a/src/main/java/org/neociclo/x25/facilities/FacilitiesSupport.java
+++ b/src/main/java/org/neociclo/x25/facilities/FacilitiesSupport.java
@@ -33,7 +33,7 @@ public class FacilitiesSupport {
         FacilitiesSupport facilities = new FacilitiesSupport();
 
         // prepare regressive counter based on facilities length field
-        byte count = (byte) (buf.get() - 1);
+        byte count = (byte) (buf.get());
 
         while (count > 0) {
             byte encodedType = buf.get();
@@ -94,15 +94,15 @@ public class FacilitiesSupport {
 
     public byte[] encoded() {
 
-        byte[] block = new byte[getBlockSize() + 1];
-        block[0] = (byte) block.length;
+        byte[] block = new byte[getBlockSize()+1];
+        block[0] = (byte) (block.length-1) ;
 
         byte counter = 0;
         Collection<Facility> col = facilities.values();
         for (Facility f : col) {
             byte[] fencode = f.encoded();
             System.arraycopy(fencode, 0, block, counter + 1, fencode.length);
-            counter++;
+            counter=(byte) (counter+((byte)fencode.length)); //Move fencode.length bytes
         }
 
         return block;


### PR DESCRIPTION
-Jcapi changes in jcapiadapter. Jcapi project now manages b3data in a
different way (not in the message byte array but in a different
variable).
- x25 facilities bugfixes
- config to select if you don't want to create NCPI on CONNECT_B3 CONF
- Added userdata optional maximum 16 bytes on NCPI plp.

-Tested with jcapi created from the latest sources. I could attach 32 and 64 bits jcapi20xx.dll and jcapi.jar if you want.
